### PR TITLE
Une implémentation de menus avec déclaration explicite

### DIFF
--- a/site/content/tokens/colors.md
+++ b/site/content/tokens/colors.md
@@ -1,6 +1,7 @@
 ---
 title: "Couleurs"
 date: 2017-12-13T20:36:14+01:00
+menu: "tokens"
 ---
 
 # Couleurs

--- a/site/content/tokens/logo.md
+++ b/site/content/tokens/logo.md
@@ -1,6 +1,7 @@
 ---
 title: "Logo"
 date: 2017-12-13T20:36:14+01:00
+menu: "tokens"
 ---
 
 # Logo

--- a/site/content/tokens/typography.md
+++ b/site/content/tokens/typography.md
@@ -1,6 +1,7 @@
 ---
 title: "Typographie"
 date: 2017-12-13T20:36:14+01:00
+menu: "tokens"
 ---
 
 # Typographie

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -1,19 +1,16 @@
 <nav>
+
     <ul>
+        {{ $currentPage := . }}
         <li>
             Tokens
             <ul>
-                <li>
-                    <a href="/tokens/logo">Logo</a>
+            {{ range .Site.Menus.tokens }}
+                <li class="{{if or ($currentPage.IsMenuCurrent "tokens" .) ($currentPage.HasMenuCurrent "tokens" .) }} active{{end}}">
+                    <a href="{{.URL}}">{{ .Name }}</a>
                 </li>
-                <li>
-                    <a href="/tokens/colors">Couleurs</a>
-                </li>
-                <li>
-                    <a href="/tokens/typography">Typographie</a>
-                </li>
-            </ul>
+            {{ end }}
+             </ul>
         </li>
     </ul>
 </nav>
-

--- a/src/css/styleguide/partials/nav.css
+++ b/src/css/styleguide/partials/nav.css
@@ -10,6 +10,11 @@ nav li {
   padding: 0;
   font-weight: bold;
 }
+nav li.active a {
+  color: #f45099;
+  font-weight: bold;
+  text-decoration: none;
+}
 nav ul ul {
   padding-left: 1rem;
 }


### PR DESCRIPTION
... au sein de chaque content

Une autre implémentation qui serait possible (mais je pense moins souple) serait de les grouper par un champ en particulier automatiquement (exemple par `.Section`), comme présenté dans https://gohugo.io/templates/lists/#group-content