### PR TITLE
Fix text overflow on logo in the footer – fixes SITE-654

### DIFF
--- a/src/css/modules/footer.css
+++ b/src/css/modules/footer.css
@@ -23,8 +23,9 @@
   text-decoration: underline;
 }
 
-.footer-title img {
+.footer__description img {
   width: 5em;
+  max-width: 100%;
   display: block;
 }
 
@@ -86,8 +87,6 @@
     margin-left: 0;
   }
   .footer__description img {
-    width: 5em;
-    display: block;
     margin-bottom: calc(var(--base-spacing) * 2);
   }
 


### PR DESCRIPTION
Comme proposé par @nico3333fr j’ai ajouté un `max-width` et en ai profité pour corriger la règle CSS car le HTML associé au composant utilise un id pour le `footer-title` donc j’ai réutilisé le sélecteur utilisé dans le plus grand viewport.

Aperçu : https://www.paris-web.fr/design-system/overflow-logo-footer/modules/footer/

Sauf mention contraire je mergerai ça demain. 